### PR TITLE
Enable optional host permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Project Overview
+
+Smart Site Redirector is a Manifest V3 browser extension that redirects distracting sites to safer destinations. Rules are managed by `background.js` using `declarativeNetRequest` while `popup.js` powers the configuration UI.
+
+### Key Files
+- **manifest.json** – extension configuration and permissions
+- **background.js** – service worker with redirect logic
+- **popup.js** – UI logic for managing rules and whitelist
+- **updates.md** – security notes and planned improvements
+
+### Development
+Run simple syntax checks with:
+
+```bash
+node -c popup.js
+node -c background.js
+```
+
+This repository currently focuses on minimizing host permissions. Optional host permissions allow prompting for new domains when users add them to rules or the whitelist.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ incognito windows.
 - **Import/Export** – Backup your rules to a JSON file or restore them later.
 - **Loop prevention and validation** – URLs are sanitized and checked against an
 allowed destination list to avoid unsafe or infinite redirects.
+- **Domain-scoped permissions** – The extension only requests host access for
+  domains you specify in rules or the whitelist. Any additional domains are
+  requested individually using optional host permissions, minimizing exposure.
 
 ## How It Works
 

--- a/manifest.json
+++ b/manifest.json
@@ -19,9 +19,7 @@
   ],
   "optional_host_permissions": [
     "*://*/*"
-
   ],
-  "optional_host_permissions": [],
   "background": {
     "service_worker": "background.js"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Smart Site Redirector",
-  "version": "2.3",
+  "version": "2.5",
   "description": "Secure, privacy-focused site redirector for productivity",
   "permissions": [
     "storage",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Smart Site Redirector",
-  "version": "2.2",
+  "version": "2.3",
   "description": "Secure, privacy-focused site redirector for productivity",
   "permissions": [
     "storage",
@@ -12,7 +12,13 @@
     "notifications"
   ],
   "host_permissions": [
-    "<all_urls>"
+    "*://youtube.com/*",
+    "*://*.youtube.com/*",
+    "*://reddit.com/*",
+    "*://*.reddit.com/*"
+  ],
+  "optional_host_permissions": [
+    "*://*/*"
   ],
   "background": {
     "service_worker": "background.js"

--- a/popup.js
+++ b/popup.js
@@ -533,7 +533,7 @@ async function ensureHostPermissions(domains) {
         resolve(false);
         return;
       }
-
+}
       resolve(granted);
     });
   });

--- a/popup.js
+++ b/popup.js
@@ -533,7 +533,6 @@ async function ensureHostPermissions(domains) {
         resolve(false);
         return;
       }
-}
       resolve(granted);
     });
   });

--- a/popup.js
+++ b/popup.js
@@ -236,13 +236,7 @@ async function saveRule() {
     priority: 3 // General priority
   };
 
-  const granted = await ensureHostPermissions(from);
-  if (!granted) {
-    showStatus('Host permission denied for one or more domains', 'error');
-    return;
-  }
-  
-  // Add or update rule
+  // Add or update rule first
   if (editingRuleIndex !== null) {
     rules[editingRuleIndex] = rule;
   } else {
@@ -256,7 +250,17 @@ async function saveRule() {
   await loadSettings();
   closeRuleModal();
   
-  showStatus(editingRuleIndex !== null ? 'Rule updated successfully' : 'Rule added successfully', 'success');
+  // Request permissions after saving (non-blocking)
+  ensureHostPermissions(from).then(granted => {
+    if (granted) {
+      showStatus(editingRuleIndex !== null ? 'Rule updated successfully' : 'Rule added successfully', 'success');
+    } else {
+      showStatus('Rule saved but permission denied - rule may not work properly', 'error');
+    }
+  });
+  
+  // Show immediate feedback
+  showStatus('Rule saved, requesting permissions...', 'success');
 }
 
 // Tab management

--- a/popup.js
+++ b/popup.js
@@ -235,6 +235,12 @@ async function saveRule() {
     enabled: enabled,
     priority: 3 // General priority
   };
+
+  const granted = await ensureHostPermissions(from);
+  if (!granted) {
+    showStatus('Host permission denied for one or more domains', 'error');
+    return;
+  }
   
   // Add or update rule
   if (editingRuleIndex !== null) {
@@ -412,7 +418,13 @@ async function addToWhitelist() {
     showStatus('Domain already whitelisted', 'error');
     return;
   }
-  
+
+  const granted = await ensureHostPermissions([domain]);
+  if (!granted) {
+    showStatus('Host permission denied for domain', 'error');
+    return;
+  }
+
   // Add to whitelist
   whitelistedDomains.push(domain);
   await saveToStorage({ whitelistedDomains });
@@ -460,6 +472,8 @@ async function importSettings(event) {
     if (response.success) {
       showStatus(`Imported ${response.rulesImported} rules successfully`, 'success');
       await loadSettings(); // Reload UI
+      const domains = rules.flatMap(r => r.from).concat(whitelistedDomains);
+      await ensureHostPermissions(domains);
     } else {
       showStatus(`Import failed: ${response.error}`, 'error');
     }
@@ -495,8 +509,31 @@ function showStatus(message, type) {
   const statusDiv = document.getElementById('statusMessage');
   statusDiv.textContent = message;
   statusDiv.className = `status-message ${type}`;
-  
+
   setTimeout(() => {
     statusDiv.className = 'status-message';
   }, 3000);
+}
+
+// Ensure host permissions for given domains
+async function ensureHostPermissions(domains) {
+  const originsToRequest = [];
+  for (const domain of domains) {
+    const origin = `*://${domain}/*`;
+    const hasPermission = await chrome.permissions.contains({ origins: [origin] });
+    if (!hasPermission) originsToRequest.push(origin);
+  }
+  if (originsToRequest.length === 0) {
+    return true;
+  }
+  return new Promise((resolve) => {
+    chrome.permissions.request({ origins: originsToRequest }, (granted) => {
+      if (chrome.runtime.lastError) {
+        console.error('Permission request failed', chrome.runtime.lastError);
+        resolve(false);
+        return;
+      }
+      resolve(granted);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- allow requesting host permissions by adding `*://*/*` to optional_host_permissions
- show an error if permission prompts fail
- document how optional permissions keep access scoped to chosen domains

## Testing
- `node -c popup.js`
- `node -c background.js`


------
https://chatgpt.com/codex/tasks/task_e_685e58eebaa48325a2a1f253661df20e